### PR TITLE
ci: drive package version from the VERSION repo variable

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,16 +2,22 @@ name: Publish to NuGet
 
 on:
   push:
-    branches: [ "master" ]
-    tags: [ "v*.*.*" ]
+    branches: ["master"]
 
 jobs:
   publish:
     runs-on: ubuntu-latest
 
+    # Published version comes from the `VERSION` repository variable
+    # (Settings -> Secrets and variables -> Actions -> Variables). After a
+    # successful publish, the patch is incremented and written back to the
+    # variable. Edit the variable to set or jump the version (e.g. 8.1.0).
+    env:
+      VERSION: ${{ vars.VERSION }}
+
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
@@ -22,10 +28,22 @@ jobs:
         run: dotnet restore
 
       - name: Build the project
-        run: dotnet build --configuration Release --no-restore
+        run: dotnet build --configuration Release --no-restore -p:Version=$VERSION
 
       - name: Pack the project
-        run: dotnet pack --configuration Release --no-build -o ./out
+        run: dotnet pack --configuration Release --no-build -o ./out -p:Version=$VERSION
 
       - name: Publish to NuGet
-        run: dotnet nuget push ./out/*.nupkg --api-key ${{ secrets.GH_PAT }} --source "https://nuget.pkg.github.com/bladehero/index.json"
+        run: dotnet nuget push ./out/*.nupkg --api-key ${{ secrets.GH_PAT }} --source "https://nuget.pkg.github.com/bladehero/index.json" --skip-duplicate
+
+      # Increment the patch and store it back in the VERSION variable so the
+      # next merge to master publishes the following version. Requires GH_PAT
+      # to have variable-write scope (classic `repo` or fine-grained Variables).
+      - name: Bump patch version for next run
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          IFS='.' read -r major minor patch <<< "$VERSION"
+          next="$major.$minor.$((patch + 1))"
+          echo "Published $VERSION; setting VERSION variable to $next"
+          gh variable set VERSION --body "$next" --repo "$GITHUB_REPOSITORY"

--- a/Assembly.Extensions/Assembly.Extensions.csproj
+++ b/Assembly.Extensions/Assembly.Extensions.csproj
@@ -4,7 +4,6 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Assembly.Extensions</PackageId>
-        <Version>8.0.0</Version>
         <Authors>bladehero</Authors>
         <PackageDescription>Assembly.Extensions</PackageDescription>
         <RepositoryUrl>https://github.com/bladehero/Assembly.Extensions</RepositoryUrl>


### PR DESCRIPTION
## Summary
Replaces the hardcoded csproj `<Version>` with a GitHub Actions **repository variable `VERSION`** (created, set to `8.0.0`). Each merge to `master` publishes the current value, then the workflow increments the patch and writes it back — gap-free, no commit-back, no `run_number`.

- `env: VERSION: ${{ vars.VERSION }}`; build/pack use `-p:Version=$VERSION`.
- Publish step now uses `--skip-duplicate`; new **Bump** step (`gh variable set VERSION`).
- Dropped the `tags` trigger (master-only, matching the scheme); checkout bumped to v4.
- Removed `<Version>8.0.0</Version>` from the csproj.

## ⚠️ Requires GH_PAT with variable-write scope
The bump step needs `secrets.GH_PAT` to have classic `repo` (or fine-grained *Variables: Read and write*) scope; `GITHUB_TOKEN` cannot manage variables. Without it the package still publishes but the version won't advance.

Note: with `--skip-duplicate`, if `8.0.0` is already published the first run is a no-op publish and then bumps to `8.0.1`. Set the variable to the next patch in settings if you want an immediate publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)